### PR TITLE
Set traefik `--serverstransport.insecureskipverify=true`

### DIFF
--- a/files/alpha/k3s/data/server/manifests/traefik-config.yaml
+++ b/files/alpha/k3s/data/server/manifests/traefik-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    additionalArguments:
+      - --serverstransport.insecureskipverify=true


### PR DESCRIPTION
This allows sending traffic to a backend that only accepts HTTPS, like unifi, even if we don't have a valid cert