### PR TITLE
Add `bravo` as a disabled longhorn node

### DIFF
--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -13,3 +13,4 @@ k3s_node
 
 [longhorn_node]
 alpha
+bravo


### PR DESCRIPTION
It has an empty `longhorn_default_disks_config`, so it will be added as a node but won't contribute any storage.