### PR TITLE
Fix issues with Raspberry Pi setup

### DIFF
--- a/roles/k3s/tasks/prereqs/rpios.yml
+++ b/roles/k3s/tasks/prereqs/rpios.yml
@@ -6,4 +6,9 @@
     line: '\1 cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
   become: true
-  notify: reboot
+  register: enable_cgroups
+
+- name: Reboot
+  ansible.builtin.reboot:
+  become: true
+  when: enable_cgroups.changed

--- a/roles/longhorn/tasks/nfs/rpios.yml
+++ b/roles/longhorn/tasks/nfs/rpios.yml
@@ -3,6 +3,7 @@
   community.general.modprobe:
     name: configs
     state: present
+  become: true
 
 - name: Unarchive kernel config
   command:


### PR DESCRIPTION
1. Add a reboot step if cgroups are enabled because there is no `reboot` handler to use with `notify`, and that would be done at the end anyway, whereas this needs to happen serially before k3s is installed
2. Use sudo for modprobe